### PR TITLE
feat: allow configuring async and defer options of turnstile scripts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -231,6 +233,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.0-arm64-darwin)
+    sqlite3 (1.6.0-x86_64-darwin)
     sqlite3 (1.6.0-x86_64-linux)
     standard (1.22.0)
       language_server-protocol (~> 3.17.0.2)
@@ -252,6 +255,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/rails_cloudflare_turnstile/view_helpers.rb
+++ b/lib/rails_cloudflare_turnstile/view_helpers.rb
@@ -14,13 +14,13 @@ module RailsCloudflareTurnstile
       end
     end
 
-    def cloudflare_turnstile_script_tag
+    def cloudflare_turnstile_script_tag(async: true, defer: true)
       if RailsCloudflareTurnstile.enabled?
-        content_tag(:script, :src => js_src, "async" => true) do
+        content_tag(:script, src: js_src, async: async, defer: defer) do
           ""
         end
       elsif RailsCloudflareTurnstile.mock_enabled?
-        content_tag(:script, :src => mock_js, "async" => true) do
+        content_tag(:script, src: mock_js, async: async, defer: defer) do
           ""
         end
       end

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -46,7 +46,17 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
       end
     end
 
-    its(:cloudflare_turnstile_script_tag) { should eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" async=\"async\"></script>" }
+    describe "#cloudflare_turnstile_script_tag" do
+      it "should allow overriding async and defer" do
+        expect(subject.cloudflare_turnstile_script_tag(async: false, defer: false)).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\"></script>"
+        expect(subject.cloudflare_turnstile_script_tag(async: true, defer: false)).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" async=\"async\"></script>"
+        expect(subject.cloudflare_turnstile_script_tag(async: false, defer: true)).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" defer=\"defer\"></script>"
+      end
+
+      it "generates a script tag with async and defer" do
+        expect(subject.cloudflare_turnstile_script_tag).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" async=\"async\" defer=\"defer\"></script>"
+      end
+    end
 
     describe "#cloudflare_turnstile" do
       it do
@@ -63,7 +73,7 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
       end
     end
 
-    its(:cloudflare_turnstile_script_tag) { should eq "<script src=\"/mock/mock_cloudflare_turnstile_api.js\" async=\"async\"></script>" }
+    its(:cloudflare_turnstile_script_tag) { should eq "<script src=\"/mock/mock_cloudflare_turnstile_api.js\" async=\"async\" defer=\"defer\"></script>" }
 
     describe "#cloudflare_turnstile" do
       it do


### PR DESCRIPTION
According to the official documentation, it is suggested to use `defer` combined with `async`. In this PR, we are introducing the suggested behavior. 

<img width="533" alt="Screenshot 2023-02-03 at 14 30 29" src="https://user-images.githubusercontent.com/1655222/216594411-7a264f1b-3983-4c82-88fb-42df8f03208d.png">
