### PR TITLE
chore: update nokogiri to 1.16.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7
         with:
           bundler-cache: true
-          ruby-version: "3.1"
+          ruby-version: "3.3"
       - name: Publish gem
         run: |
           umask 077

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   webmock (~> 3.19)
 
 BUNDLED WITH
-   2.5.5
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_cloudflare_turnstile (0.1.6)
+    rails_cloudflare_turnstile (0.2.0)
       faraday (>= 1.0, < 3.0)
       rails (>= 6.0, < 8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,6 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
     minitest (5.20.0)
     multipart-post (2.3.0)
     net-imap (0.3.7)
@@ -139,11 +138,13 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.5-arm64-darwin)
+    nokogiri (1.16.2-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-linux)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.2.2.4)
@@ -238,8 +239,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-aarch64-linux)
+    sqlite3 (1.7.0-arm64-darwin)
+    sqlite3 (1.7.0-x86_64-darwin)
+    sqlite3 (1.7.0-x86_64-linux)
     standard (1.33.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -267,7 +270,9 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 
@@ -286,4 +291,4 @@ DEPENDENCIES
   webmock (~> 3.19)
 
 BUNDLED WITH
-   2.4.3
+   2.5.5

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # RailsCloudflareTurnstile
 
-This is a Rails plugin adding support for [Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/)
+This is a Rails plugin adding support for [Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/). It works with Rails 6+, and Ruby 3.x.
 
 [![CI](https://github.com/instrumentl/rails-cloudflare-turnstile/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/instrumentl/rails-cloudflare-turnstile/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/rails_cloudflare_turnstile.svg)](https://badge.fury.io/rb/rails_cloudflare_turnstile)
 
 ## Usage
-How to use my plugin.
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/lib/rails_cloudflare_turnstile/version.rb
+++ b/lib/rails_cloudflare_turnstile/version.rb
@@ -1,3 +1,3 @@
 module RailsCloudflareTurnstile
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/rails-cloudflare-turnstile.gemspec
+++ b/rails-cloudflare-turnstile.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |spec|
   spec.summary = "Rails extension for Cloudflare's Turnstile CAPTCHA alternative"
   spec.description = <<-EOF
     Rails extension for Cloudflare's Turnstile CAPTCHA alternative. This gem should work with
-    Rails 5.x, 6.x, and 7.x, and with Faraday 1.x and 2.x.
+    Rails 6.x and 7.x, and with Faraday 1.x and 2.x.
   EOF
   spec.homepage = "https://github.com/instrumentl/rails-cloudflare-turnstile"
   spec.license = "ISC"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/instrumentl/rails-cloudflare-turnstile"


### PR DESCRIPTION
fixes GHSA-xc9x-jj77-9p9j

This drops support for Ruby 2.7, because upstream nokogiri dropped support for Ruby 2.7.