### PR TITLE
chore: bump rexml because of CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)


### PR DESCRIPTION
update rexml to 3.3.4 because of CVEs