### PR TITLE
Add turbo support

### DIFF
--- a/lib/rails_cloudflare_turnstile/view_helpers.rb
+++ b/lib/rails_cloudflare_turnstile/view_helpers.rb
@@ -16,11 +16,11 @@ module RailsCloudflareTurnstile
 
     def cloudflare_turnstile_script_tag(async: true, defer: true)
       if RailsCloudflareTurnstile.enabled?
-        content_tag(:script, src: js_src, async: async, defer: defer) do
+        content_tag(:script, src: js_src, async: async, defer: defer, data: { turbo_track: "reload", turbo_temporary: true }) do
           ""
         end
       elsif RailsCloudflareTurnstile.mock_enabled?
-        content_tag(:script, src: mock_js, async: async, defer: defer) do
+        content_tag(:script, src: mock_js, async: async, defer: defer, data: { turbo_track: "reload", turbo_temporary: true }) do
           ""
         end
       end


### PR DESCRIPTION
Fixes https://github.com/instrumentl/rails-cloudflare-turnstile/issues/63

Adds turbo support by setting the proper data-attributes in the script tag.
It's set by default, as Turbo is the Rails default since v7 (15 December 2021).
If a user doesn't use turbo, the data-attributes will just be ignored.