### PR TITLE
Update README with additional configuration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,48 @@ a `rescue_from` block.
 By default, in development and test mode, a special mock view will be inserted if real credentials are not present. To
 disable this, set the `mock_enable` property of the configuration to false.
 
+## Client Configuration
+
+The `cloudflare_turnstile` view helper simplifies Turnstile implementation by pre-populating the Turnstile tag with `sitekey`, `size`, `action`, and `theme`. However, you can pass your own [data attributes supported by Turnstile](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations) to the `cloudflare_turnstile` helper as needed.
+
+Example usage:
+```erb
+<%= cloudflare_turnstile('data-callback': 'exampleJsCallback', 'data-error-callback': 'exampleErrorJsCallback') %>
+```
+
+### Configuration Reference Table
+
+Retrieved February 2025 from [Cloudflare Configuration](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations).
+
+This table outlines the available configuration options for Turnstile, their equivalent `data-` attributes, whether they are pre-populated by the helper, and a brief description.
+
+| JavaScript Parameter          | `data-` Attribute Equivalent          | Pre-populated? | Description |
+|-------------------------------|---------------------------------------|---------------|-------------|
+| `sitekey`                     | `data-sitekey`                        | **Yes**       | The public site key for the Turnstile instance. |
+| `action`                      | `data-action`                         | **Yes**       | Custom string categorizing the request, useful for analytics. Max 32 alphanumeric characters. |
+| `cData`                       | `data-cdata`                          |               | A payload that attaches customer data to the challenge (max 255 alphanumeric characters). |
+| `callback`                    | `data-callback`                       |               | JavaScript function executed on successful validation. |
+| `error-callback`              | `data-error-callback`                 |               | JavaScript function executed on error (e.g., network issue, challenge failure). |
+| `execution`                   | `data-execution`                      |               | Controls when to obtain a token (`render`, `execute`). Defaults to `render`. |
+| `expired-callback`            | `data-expired-callback`               |               | JavaScript function executed when the token expires without resetting the widget. |
+| `before-interactive-callback` | `data-before-interactive-callback`    |               | JavaScript function executed before the challenge enters interactive mode. |
+| `after-interactive-callback`  | `data-after-interactive-callback`     |               | JavaScript function executed when the challenge exits interactive mode. |
+| `unsupported-callback`        | `data-unsupported-callback`           |               | JavaScript function executed if the client/browser is not supported. |
+| `theme`                       | `data-theme`                          | **Yes**       | Controls widget theme (`auto`, `light`, `dark`). Defaults to `auto`. |
+| `language`                    | `data-language`                       |               | Widget language. `auto` (default) or ISO 639-1 language code (e.g., `en`, `en-US`). |
+| `tabindex`                    | `data-tabindex`                       |               | The `tabindex` of Turnstile's iframe for accessibility. Defaults to `0`. |
+| `timeout-callback`            | `data-timeout-callback`               |               | JavaScript function executed if the interactive challenge times out. |
+| `response-field`              | `data-response-field`                 |               | Boolean to control whether an input element with the response token is created. Defaults to `true`. |
+| `response-field-name`         | `data-response-field-name`            |               | Name of the input element. Defaults to `cf-turnstile-response`. |
+| `size`                        | `data-size`                           | **Yes**       | Widget size (`normal`, `flexible`, `compact`). |
+| `retry`                       | `data-retry`                          |               | Controls automatic retries (`auto`, `never`). Defaults to `auto`. |
+| `retry-interval`              | `data-retry-interval`                 |               | Retry interval in milliseconds (`8000` default, max `900000`). |
+| `refresh-expired`             | `data-refresh-expired`                |               | Token refresh behavior (`auto`, `manual`, `never`). Defaults to `auto`. |
+| `refresh-timeout`             | `data-refresh-timeout`                |               | Controls refresh behavior on interactive challenge timeout (`auto`, `manual`, `never`). Defaults to `auto`. |
+| `appearance`                  | `data-appearance`                     |               | Widget visibility (`always`, `execute`, `interaction-only`). Defaults to `always`. |
+| `feedback-enabled`            | `data-feedback-enabled`               |               | Allows visitor feedback on widget failure (`true`, `false`). Defaults to `true`. |
+
+For additional details, refer to the [Cloudflare Turnstile documentation](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations).
+
 ## License
 The gem is available as open source under the terms of the [ISC License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The `cloudflare_turnstile` view helper simplifies Turnstile implementation by pr
 
 Example usage:
 ```erb
-<%= cloudflare_turnstile('data-callback': 'exampleJsCallback', 'data-error-callback': 'exampleErrorJsCallback') %>
+<%= cloudflare_turnstile(data: { callback: 'exampleJsCallback', 'error-callback': 'handleErrorJsCallback' }) %>
 ```
 
 ### Configuration Reference Table


### PR DESCRIPTION
Thanks for putting this Gem together!

I have two sites that I'm applying this to and had to dig a little to find information about javascript callbacks to enable a submit button. 

## Proposal
This PR adds client-side reference configuration options available from [Cloudflare's own documentation](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations) and adds reference use cases.