### PR TITLE
Updates size to match the API docs

### DIFF
--- a/lib/rails_cloudflare_turnstile/configuration.rb
+++ b/lib/rails_cloudflare_turnstile/configuration.rb
@@ -33,7 +33,7 @@ module RailsCloudflareTurnstile
       @enabled = nil
       @mock_enabled = nil
       @timeout = 5.0
-      @size = :regular
+      @size = :normal
       @theme = :auto
       @validation_url = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
     end

--- a/lib/rails_cloudflare_turnstile/configuration.rb
+++ b/lib/rails_cloudflare_turnstile/configuration.rb
@@ -16,7 +16,7 @@ module RailsCloudflareTurnstile
     # Timeout for operations with Cloudflare
     attr_accessor :timeout
 
-    # size for the widget (:regular or :compact)
+    # size for the widget (:normal, :flexible, or :compact)
     attr_accessor :size
 
     # theme for the widget (:auto, :light, or :dark)
@@ -42,7 +42,7 @@ module RailsCloudflareTurnstile
       raise "Must set site key" if @site_key.nil?
       raise "Must set secret key" if @secret_key.nil?
       @size = @size.to_sym
-      raise "Size must be one of ':regular' or ':compact'" unless [:regular, :compact].include? @size
+      raise "Size must be one of ':normal', ':flexible', or ':compact'" unless [:normal, :flexible, :compact].include? @size
       raise "Theme must be one of :auto, :light, or :dark" unless [:auto, :light, :dark].include? @theme
     end
 

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
 
     describe "#cloudflare_turnstile" do
       it do
-        expect(subject.cloudflare_turnstile(action: "an-action")).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"an-action\" data-theme=\"auto\"></div></div>"
+        expect(subject.cloudflare_turnstile(action: "an-action")).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"auto\"></div></div>"
       end
 
       it "passes through HTML options" do
-        expect(subject.cloudflare_turnstile(action: "an-action", data: {appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"an-action\" data-theme=\"auto\" data-appearance=\"interaction-only\"></div></div>"
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"auto\" data-appearance=\"interaction-only\"></div></div>"
       end
     end
   end


### PR DESCRIPTION
The client-side code gives this warning:
<img width="499" alt="image" src="https://github.com/user-attachments/assets/ae205235-67cc-44b6-af27-ca8adc65ebfd" />

Looks like 'regular' has been removed and now it only takes `normal`, `flexible`, `compact`.  See their docs here: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/ 