### PR TITLE
Add install generator and initializer template for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Or install it yourself as:
 $ gem install rails_cloudflare_turnstile
 ```
 
-Next, configure it by creating a `config/initializers/cloudflare_turnstile.rb` with contents like the following:
+Next, configure it by running the install generator `rails g rails_cloudflare_turnstile:install` that will create `config/initializers/cloudflare_turnstile.rb`
+for you with contents like the following:
 
 ```ruby
 RailsCloudflareTurnstile.configure do |c|

--- a/lib/generators/install/USAGE
+++ b/lib/generators/install/USAGE
@@ -1,0 +1,2 @@
+Description:
+  Creates an initializer for rails-cloudflare-turnstile with default values

--- a/lib/generators/install/install_generator.rb
+++ b/lib/generators/install/install_generator.rb
@@ -1,0 +1,34 @@
+module RailsCloudflareTurnstile
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
+      def create_initializer
+        initializer "cloudflare_turnstile.rb" do
+          <<~RUBY
+            RailsCloudflareTurnstile.configure do |c|
+              # The site key and secret key assuming they are stored in Rails credentials
+              # You can also use ENV variables or any other method to store your keys
+              c.site_key = Rails.application.credentials.cloudflare_turnstile[:site_key]
+              c.secret_key = Rails.application.credentials.cloudflare_turnstile[:secret_key]
+
+              # Only enable the real Turnstile verification in production
+              # In development and test, a mock will be used
+              c.enabled = Rails.env.production?
+
+              c.fail_open = true
+            end
+          RUBY
+        end
+      end
+
+      def add_to_layout
+        insert_into_file "app/views/layouts/application.html.erb", before: "</head>" do
+          <<~HTML
+            <%= cloudflare_turnstile_script_tag %>\n
+          HTML
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `rails g rails_cloudflare_turnstile:install` generator that will automatically create an initializer file and add the `cloudflare_turnstile_script_tag` line to the layout.
