### PR TITLE
fix: default widget size

### DIFF
--- a/lib/rails_cloudflare_turnstile/configuration.rb
+++ b/lib/rails_cloudflare_turnstile/configuration.rb
@@ -16,7 +16,7 @@ module RailsCloudflareTurnstile
     # Timeout for operations with Cloudflare
     attr_accessor :timeout
 
-    # size for the widget (:regular, :compact, or :flexible)
+    # size for the widget (:normal, :compact, or :flexible)
     attr_accessor :size
 
     # theme for the widget (:auto, :light, or :dark)
@@ -33,7 +33,7 @@ module RailsCloudflareTurnstile
       @enabled = nil
       @mock_enabled = nil
       @timeout = 5.0
-      @size = :regular
+      @size = :normal
       @theme = :auto
       @validation_url = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
     end
@@ -42,7 +42,7 @@ module RailsCloudflareTurnstile
       raise "Must set site key" if @site_key.nil?
       raise "Must set secret key" if @secret_key.nil?
       @size = @size.to_sym
-      raise "Size must be one of ':regular', ':compact' or ':flexible'" unless [:regular, :compact, :flexible].include? @size
+      raise "Size must be one of ':normal', ':compact' or ':flexible'" unless [:normal, :compact, :flexible].include? @size
       raise "Theme must be one of :auto, :light, or :dark" unless [:auto, :light, :dark].include? @theme
     end
 

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -64,15 +64,15 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
 
     describe "#cloudflare_turnstile" do
       it do
-        expect(subject.cloudflare_turnstile(action: "an-action")).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"an-action\" data-theme=\"auto\"></div></div>"
+        expect(subject.cloudflare_turnstile(action: "an-action")).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"auto\"></div></div>"
       end
 
       it "passes through HTML options" do
-        expect(subject.cloudflare_turnstile(action: "an-action", data: {appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"an-action\" data-theme=\"auto\" data-appearance=\"interaction-only\"></div></div>"
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"auto\" data-appearance=\"interaction-only\"></div></div>"
       end
 
       it "passes through container classes" do
-        expect(subject.cloudflare_turnstile(container_class: "wrapper")).to eq "<div class=\"cloudflare-turnstile wrapper\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"other\" data-theme=\"auto\"></div></div>"
+        expect(subject.cloudflare_turnstile(container_class: "wrapper")).to eq "<div class=\"cloudflare-turnstile wrapper\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"other\" data-theme=\"auto\"></div></div>"
       end
     end
   end


### PR DESCRIPTION
Currently, the default widget size is `regular` which does not exist and so the following warning is displayed in the JS console:
`[Cloudflare Turnstile] Unknown data-size value: "regular"`

The following widget sizes are available:
- normal
- flexible
- compact

https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#widget-size

I renamed `regular` to `normal` to fix the issue.