### PR TITLE
Fix size and theme being ignored in html_options

### DIFF
--- a/lib/rails_cloudflare_turnstile/view_helpers.rb
+++ b/lib/rails_cloudflare_turnstile/view_helpers.rb
@@ -32,7 +32,16 @@ module RailsCloudflareTurnstile
 
     def turnstile_div(action, data_callback: nil, **html_options)
       config = RailsCloudflareTurnstile.configuration
-      content_tag(:div, :class => "cf-turnstile", "data-sitekey" => site_key, "data-size" => config.size, "data-action" => action, "data-callback" => data_callback, "data-theme" => config.theme, **html_options) do
+      data = html_options[:data] || {}
+      size = data[:size] || config.size
+      theme = data[:theme] || config.theme
+
+      if html_options[:data]
+        html_options[:data] = html_options[:data].except(:size, :theme)
+        html_options.delete(:data) if html_options[:data].empty?
+      end
+
+      content_tag(:div, :class => "cf-turnstile", "data-sitekey" => site_key, "data-size" => size, "data-action" => action, "data-callback" => data_callback, "data-theme" => theme, **html_options) do
         ""
       end
     end

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
         expect(subject.cloudflare_turnstile(action: "an-action", data: {appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"an-action\" data-theme=\"auto\" data-appearance=\"interaction-only\"></div></div>"
       end
 
+      it "overrides size and theme config through HTML options" do
+        expect(subject.cloudflare_turnstile(data: {size: "compact", theme: "light"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"compact\" data-action=\"other\" data-theme=\"light\"></div></div>"
+      end
+
       it "passes through container classes" do
         expect(subject.cloudflare_turnstile(container_class: "wrapper")).to eq "<div class=\"cloudflare-turnstile wrapper\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"regular\" data-action=\"other\" data-theme=\"auto\"></div></div>"
       end


### PR DESCRIPTION
The view_helper private method `turnstile_div` ignores `size`and `theme` when they are passed in via `data`.

I added a check for both to see if they are passed inside of `data` first before taking the `config` default.
I then remove them from `html_options` since they are now used and delete `data` if its empty.

I also added a test for it.

Fixes (https://github.com/instrumentl/rails-cloudflare-turnstile/issues/215)