### PR TITLE
chore: fix a number of CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     minitest (5.25.4)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
-    net-imap (0.5.6)
+    net-imap (0.5.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -167,13 +167,13 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.7-aarch64-linux-gnu)
+    nokogiri (1.18.8-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.7-arm64-darwin)
+    nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.7-x86_64-darwin)
+    nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.7-x86_64-linux-gnu)
+    nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -187,8 +187,9 @@ GEM
       stringio
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (3.1.12)
-    rack-session (2.0.0)
+    rack (3.1.15)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)


### PR DESCRIPTION
[As per this bundle-audit](https://github.com/instrumentl/rails-cloudflare-turnstile/actions/runs/14728739655/job/42667675115?pr=219).

```
Name: net-imap
Version: 0.5.6
CVE: CVE-2025-43857
GHSA: GHSA-j3g3-5qv5-52mj
Criticality: Unknown
URL: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
Title: net-imap rubygem vulnerable to possible DoS by memory exhaustion
Solution: update to '~> 0.2.5', '~> 0.3.9', '~> 0.4.20', '>= 0.5.7'

Name: nokogiri
Version: 1.18.7
GHSA: GHSA-5w6v-399v-w3cc
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5w6v-399v-w3cc
Title: Nokogiri updates packaged libxml2 to v2.13.8 to resolve CVE-2025-32414 and CVE-2025-32415
Solution: update to '>= 1.18.8'

Name: nokogiri
Version: 1.18.7
GHSA: GHSA-5w6v-399v-w3cc
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5w6v-399v-w3cc
Title: Nokogiri updates packaged libxml2 to v2.13.8 to resolve CVE-2025-32414 and CVE-2025-32415
Solution: update to '>= 1.18.8'

Name: nokogiri
Version: 1.18.7
GHSA: GHSA-5w6v-399v-w3cc
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5w6v-399v-w3cc
Title: Nokogiri updates packaged libxml2 to v2.13.8 to resolve CVE-2025-32414 and CVE-2025-32415
Solution: update to '>= 1.18.8'

Name: nokogiri
Version: 1.18.7
GHSA: GHSA-5w6v-399v-w3cc
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5w6v-399v-w3cc
Title: Nokogiri updates packaged libxml2 to v2.13.8 to resolve CVE-2025-32414 and CVE-2025-32415
Solution: update to '>= 1.18.8'

Name: rack
Version: 3.1.[12](https://github.com/instrumentl/rails-cloudflare-turnstile/actions/runs/14728739655/job/42667675115?pr=219#step:4:13)
CVE: CVE-2025-46727
GHSA: GHSA-gjh7-p2fx-99vx
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-gjh7-p2fx-99vx
Title: Rack has an Unbounded-Parameter DoS in Rack::QueryParser
Solution: update to '~> 2.2.[14](https://github.com/instrumentl/rails-cloudflare-turnstile/actions/runs/14728739655/job/42667675115?pr=219#step:4:15)', '~> 3.0.16', '>= 3.1.14'

Name: rack-session
Version: 2.0.0
CVE: CVE-2025-46336
GHSA: GHSA-9j94-67jr-4cqj
Criticality: Medium
URL: https://github.com/rack/rack-session/security/advisories/GHSA-9j94-67jr-4cqj
Title: Rack session gets restored after deletion
Solution: update to '>= 2.1.1'
```