### PR TITLE
Feat/add additional params to js src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bundle
 .env
 *.gem
+.idea/

--- a/lib/rails_cloudflare_turnstile/view_helpers.rb
+++ b/lib/rails_cloudflare_turnstile/view_helpers.rb
@@ -16,9 +16,9 @@ module RailsCloudflareTurnstile
       end
     end
 
-    def cloudflare_turnstile_script_tag(async: true, defer: true, explicit: false)
+    def cloudflare_turnstile_script_tag(async: true, defer: true, explicit: false, additional_params: [])
       if RailsCloudflareTurnstile.enabled?
-        content_tag(:script, src: js_src(explicit:), async: async, defer: defer, data: {turbo_track: "reload", turbo_temporary: true}) do
+        content_tag(:script, nil, src: js_src(explicit:, additional_params:), async: async, defer: defer, data: {turbo_track: "reload", turbo_temporary: true}) do
           ""
         end
       elsif RailsCloudflareTurnstile.mock_enabled?
@@ -53,12 +53,13 @@ module RailsCloudflareTurnstile
       RailsCloudflareTurnstile.configuration.site_key
     end
 
-    def js_src(explicit: false)
-      if explicit
-        "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-      else
-        "https://challenges.cloudflare.com/turnstile/v0/api.js"
-      end
+    def js_src(explicit: false, additional_params: [])
+      base_url = "https://challenges.cloudflare.com/turnstile/v0/api.js"
+      return base_url if !explicit && additional_params.blank?
+
+      additional_params.unshift("render=explicit") if explicit
+
+      "#{base_url}?#{additional_params.join("&")}"
     end
 
     def mock_js

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
       it "should allow using the explicitly rendered version of widget" do
         expect(subject.cloudflare_turnstile_script_tag(explicit: true)).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit\" async=\"async\" defer=\"defer\" data-turbo-track=\"reload\" data-turbo-temporary=\"true\"></script>"
       end
+
+      it "should add additional params to the script tag" do
+        expect(subject.cloudflare_turnstile_script_tag(additional_params: ["onload=onloadCallback"])).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadCallback\" async=\"async\" defer=\"defer\" data-turbo-track=\"reload\" data-turbo-temporary=\"true\"></script>"
+      end
+
+      it "should add the explicit render and any additional params to the script tag" do
+        expect(subject.cloudflare_turnstile_script_tag(explicit: true, additional_params: ["onload=onloadCallback"])).to eq "<script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&amp;onload=onloadCallback\" async=\"async\" defer=\"defer\" data-turbo-track=\"reload\" data-turbo-temporary=\"true\"></script>"
+      end
     end
 
     describe "#cloudflare_turnstile" do


### PR DESCRIPTION
Pertaining to issue: https://github.com/instrumentl/rails-cloudflare-turnstile/issues/226

Used an array to ensure `render=explicit` is always set first when added.