### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog
 =========
+0.4.3
+-----
+- Add support for Rails 8.1
+- Various dependencies updates to address CVEs
 
 0.4.2
 -----

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_cloudflare_turnstile (0.4.2)
+    rails_cloudflare_turnstile (0.4.3)
       faraday (>= 1.0, < 3.0)
       rails (>= 6.0, < 8.2)
 

--- a/lib/rails_cloudflare_turnstile/version.rb
+++ b/lib/rails_cloudflare_turnstile/version.rb
@@ -1,3 +1,3 @@
 module RailsCloudflareTurnstile
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
i accepted the PR to bump rails to 8.1 so that's the PR for the new release