### PR TITLE
Prevent duplicate `data-x` attributes and allow dynamic overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ ChangeLog
 =========
 Unreleased
 ----------
-- Fixes bug where dynamic theme override via `data` attribute resulted in duplicate `data-theme` attributes. Now when you pass `data: {theme: "dark"}` to the `cloudflare_turnstile` helper, it overrides the global theme configuration on a per-instance basis and only sets the `data-theme` attribute once.
+- Fixes bug where dynamic theme/size override via `data` attributes resulted in duplicate `data-theme` and `data-size` attributes. Now when you pass `data: {theme: "dark", size: "compact"}` to the `cloudflare_turnstile` helper, it overrides the global configuration on a per-instance basis and only outputs each attribute once.
 
 0.4.3
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog
 =========
+Unreleased
+----------
+- Fixes bug where dynamic theme override via `data` attribute resulted in duplicate `data-theme` attributes. Now when you pass `data: {theme: "dark"}` to the `cloudflare_turnstile` helper, it overrides the global theme configuration on a per-instance basis and only sets the `data-theme` attribute once.
+
 0.4.3
 -----
 - Add support for Rails 8.1

--- a/README.md
+++ b/README.md
@@ -47,5 +47,24 @@ a `rescue_from` block.
 By default, in development and test mode, a special mock view will be inserted if real credentials are not present. To
 disable this, set the `mock_enabled` property of the configuration to false.
 
+## Light and dark mode
+
+The widget theme can be configured globally and overridden per instance:
+
+**Global theme** (set in initializer):
+```ruby
+RailsCloudflareTurnstile.configure do |c|
+  c.theme = :dark  # :auto (default), :light, or :dark
+end
+```
+
+**Per-instance override** (in your view):
+```erb
+<%= cloudflare_turnstile(data: {theme: "dark"}) %>
+<%= cloudflare_turnstile(data: {theme: "light"}) %>
+```
+
+The per-instance theme will override the global configuration. Both strings and symbols are accepted.
+
 ## License
 The gem is available as open source under the terms of the [ISC License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -47,24 +47,26 @@ a `rescue_from` block.
 By default, in development and test mode, a special mock view will be inserted if real credentials are not present. To
 disable this, set the `mock_enabled` property of the configuration to false.
 
-## Light and dark mode
+## Customizing theme and size
 
-The widget theme can be configured globally and overridden per instance:
+The widget theme and size can be configured globally and overridden per instance:
 
-**Global theme** (set in initializer):
+**Global configuration** (set in initializer):
 ```ruby
 RailsCloudflareTurnstile.configure do |c|
-  c.theme = :dark  # :auto (default), :light, or :dark
+  c.size = :normal   # :normal (default), :compact, or :flexible
+  c.theme = :dark    # :auto (default), :light, or :dark
 end
 ```
 
 **Per-instance override** (in your view):
 ```erb
 <%= cloudflare_turnstile(data: {theme: "dark"}) %>
-<%= cloudflare_turnstile(data: {theme: "light"}) %>
+<%= cloudflare_turnstile(data: {size: "compact"}) %>
+<%= cloudflare_turnstile(data: {size: "compact", theme: "dark"}) %>
 ```
 
-The per-instance theme will override the global configuration. Both strings and symbols are accepted.
+Per-instance values will override the global configuration. Both strings and symbols are accepted.
 
 ## License
 The gem is available as open source under the terms of the [ISC License](LICENSE.txt).

--- a/lib/rails_cloudflare_turnstile/view_helpers.rb
+++ b/lib/rails_cloudflare_turnstile/view_helpers.rb
@@ -32,7 +32,9 @@ module RailsCloudflareTurnstile
 
     def turnstile_div(action, data_callback: nil, **html_options)
       config = RailsCloudflareTurnstile.configuration
-      content_tag(:div, :class => "cf-turnstile", "data-sitekey" => site_key, "data-size" => config.size, "data-action" => action, "data-callback" => data_callback, "data-theme" => config.theme, **html_options) do
+      theme = html_options[:data]&.delete(:theme) || config.theme
+
+      content_tag(:div, :class => "cf-turnstile", "data-sitekey" => site_key, "data-size" => config.size, "data-action" => action, "data-callback" => data_callback, "data-theme" => theme, **html_options) do
         ""
       end
     end

--- a/lib/rails_cloudflare_turnstile/view_helpers.rb
+++ b/lib/rails_cloudflare_turnstile/view_helpers.rb
@@ -32,9 +32,10 @@ module RailsCloudflareTurnstile
 
     def turnstile_div(action, data_callback: nil, **html_options)
       config = RailsCloudflareTurnstile.configuration
+      size = html_options[:data]&.delete(:size) || config.size
       theme = html_options[:data]&.delete(:theme) || config.theme
 
-      content_tag(:div, :class => "cf-turnstile", "data-sitekey" => site_key, "data-size" => config.size, "data-action" => action, "data-callback" => data_callback, "data-theme" => theme, **html_options) do
+      content_tag(:div, :class => "cf-turnstile", "data-sitekey" => site_key, "data-size" => size, "data-action" => action, "data-callback" => data_callback, "data-theme" => theme, **html_options) do
         ""
       end
     end

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
       it "passes through container classes" do
         expect(subject.cloudflare_turnstile(container_class: "wrapper")).to eq "<div class=\"cloudflare-turnstile wrapper\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"other\" data-theme=\"auto\"></div></div>"
       end
+
+      it "allows dynamic theme override with string" do
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {theme: "dark"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"dark\"></div></div>"
+      end
+
+      it "allows dynamic theme override with symbol" do
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {theme: :light})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"light\"></div></div>"
+      end
+
+      it "dynamic theme does not duplicate data-theme attribute" do
+        result = subject.cloudflare_turnstile(action: "an-action", data: {theme: "dark"})
+        expect(result.scan(/data-theme/).count).to eq 1
+      end
+
+      it "combines dynamic theme with other data attributes" do
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {theme: "dark", appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"dark\" data-appearance=\"interaction-only\"></div></div>"
+      end
     end
   end
 

--- a/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
+++ b/spec/rails_cloudflare_turnstile/view_helpers_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe RailsCloudflareTurnstile::ViewHelpers do
       it "combines dynamic theme with other data attributes" do
         expect(subject.cloudflare_turnstile(action: "an-action", data: {theme: "dark", appearance: "interaction-only"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"normal\" data-action=\"an-action\" data-theme=\"dark\" data-appearance=\"interaction-only\"></div></div>"
       end
+
+      it "allows dynamic size override with string" do
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {size: "compact"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"compact\" data-action=\"an-action\" data-theme=\"auto\"></div></div>"
+      end
+
+      it "allows dynamic size override with symbol" do
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {size: :flexible})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"flexible\" data-action=\"an-action\" data-theme=\"auto\"></div></div>"
+      end
+
+      it "allows dynamic size and theme override together" do
+        expect(subject.cloudflare_turnstile(action: "an-action", data: {size: "compact", theme: "dark"})).to eq "<div class=\"cloudflare-turnstile\"><div class=\"cf-turnstile\" data-sitekey=\"a_public_key\" data-size=\"compact\" data-action=\"an-action\" data-theme=\"dark\"></div></div>"
+      end
     end
   end
 


### PR DESCRIPTION
# Fix: Prevent duplicate `data-theme` attributes and allow dynamic overrides

## Bug Report

### Expected behavior

When passing `data: {theme: "dark"}` to the `cloudflare_turnstile` helper, the widget should render with `data-theme="dark"` instead of the configured default theme.

### Actual behavior

The helper creates duplicate `data-theme` attributes in the HTML output:

```html
<div class="cf-turnstile" data-theme="auto" data-theme="dark" ...>
```

This violates the HTML specification which states:
 > There must never be two or more attributes on the same start tag whose names are an ASCII case-insensitive match for each
 — https://html.spec.whatwg.org/multipage/syntax.html#attributes-2

Browsers typically handle this by ignoring all but the first occurrence, preventing gem users from dynamically overriding the theme on a per-instance basis.

### Steps to reproduce

```erb
<%= cloudflare_turnstile(data: {theme: "dark"}) %>
```

Inspect the raw HTML source (do not use "inspect element"; browser dev tools Elements view deduplicates attributes):

```html
<!-- Invalid: duplicate data-theme attributes -->
<div class="cf-turnstile" data-theme="auto" data-theme="dark" ...>
```

## Solution

This patch enables dynamic theme override while maintaining backward compatibility and generating valid HTML.

### Implementation

- Extract theme from `html_options[:data]` hash using `.delete` before rendering
- Fall back to `config.theme` if no override is provided
- Use idiomatic Ruby pattern: `html_options[:data]&.delete(:theme) || config.theme`

### Result

```erb
<%= cloudflare_turnstile(data: {theme: "dark"}) %>
```

```html
<!-- Valid: single data-theme attribute -->
<div class="cf-turnstile" data-theme="dark" ...>
```

```erb
<%= cloudflare_turnstile %>
```

```html
<!-- Falls back to config -->
<div class="cf-turnstile" data-theme="auto" ...>
```

### Changes

- Added tests for string themes, symbol themes, no duplication, and combination with other data attributes
- Modified turnstile_div to extract and delete theme from data hash before rendering
- Documentation: Updated README with theme configuration examples
- Changelog: Documented new feature

## Testing

All tests pass, including new tests that verify:
- Dynamic theme override with strings: `data: {theme: "dark"}`
- Dynamic theme override with symbols: `data: {theme: :light}`
- No duplicate attributes in HTML output
- Combining theme with other data attributes
- Fallback to `config.theme` when no override provided

## Possible Issues/Enhancements

### Runtime validation

This implementation does not validate runtime theme values e.g. `data: {theme: "unicorns"}`. Values are passed through as-is to the HTML output. I'm assuming the Cloudflare Turnstile JavaScript API handles them.

This matches the behavior of other data attributes (e.g. appearance, tabindex) which are also not validated at the view helper level. It also provides forward compatibility if Cloudflare adds new theme values in the future.

Config-level theme (`config.theme`) continues to be validated in `Configuration#validate!` to catch configuration errors early.

If stricter validation is desired in the future, it could be added without breaking existing functionality.