### PR TITLE
fix: add explicit permissions to release workflow (security alert #3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fixes [GitHub Security Alert #3](https://github.com/instrumentl/rails-cloudflare-turnstile/security/code-scanning/3) by adding explicit permissions to the release workflow, following the principle of least privilege.

## Changes

- Added `permissions` block to the `release` job in `.github/workflows/release.yml`
- Granted only `contents: read` permission (minimum required to checkout code)
- Consistent with permissions pattern used in `ci.yml`

## Security Context

### Issue
The release workflow was missing an explicit permissions block, which meant it inherited default repository/organization permissions. This could grant excessive permissions such as:
- `contents: write` (can modify repository code)
- `issues: write` (can create/edit issues)
- `pull-requests: write` (can create/edit PRs)
- And potentially others depending on organization settings

### Risk
- **CWE-275**: Permission Issues
- **Severity**: Medium (Warning)
- **Impact**: Potential for privilege escalation if workflow or dependencies compromised

### Solution
By explicitly setting `permissions: contents: read`, the workflow now:
- ✅ Only has read access to repository contents
- ✅ Cannot modify code, issues, PRs, or other resources
- ✅ Follows GitHub security best practices
- ✅ Adheres to principle of least privilege

## Analysis

The release workflow only needs to:
1. **Checkout code** - requires `contents: read` ✅
2. **Install Ruby/gems** - no GitHub permissions needed (downloads from ruby-lang.org)
3. **Publish gem** - no GitHub permissions needed (uses RubyGems API via secret token)

No write permissions or other GitHub access is required.

## Testing

- ✅ YAML syntax validated
- ✅ Change follows existing code patterns (matches ci.yml structure)
- ✅ Workflow functionality unchanged (only restricting permissions, not adding)
- 🔄 [Security alert #3](https://github.com/instrumentl/rails-cloudflare-turnstile/security/code-scanning/3) should be resolved after merge

## References

- **Security Alert**: [#3](https://github.com/instrumentl/rails-cloudflare-turnstile/security/code-scanning/3) (CodeQL: `actions/missing-workflow-permissions`)
- **GitHub Docs**: [Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs)
- **CWE-275**: [Permission Issues](https://cwe.mitre.org/data/definitions/275.html)