### PR TITLE
fix: update Faraday to 2.14.1 to address CVE-2026-25765

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+0.4.5
+-----
+- Update Faraday dependency to 2.14.1 to address CVE-2026-25765 (SSRF vulnerability via protocol-relative URLs)
+
 0.4.4
 ----------
 - Fixes bug where dynamic theme/size override via `data` attributes resulted in duplicate `data-theme` and `data-size` attributes. Now when you pass `data: {theme: "dark", size: "compact"}` to the `cloudflare_turnstile` helper, it overrides the global configuration on a per-instance basis and only outputs each attribute once. (thanks to @matt17r and @Gambitboy)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_cloudflare_turnstile (0.4.4)
+    rails_cloudflare_turnstile (0.4.5)
       faraday (>= 1.0, < 3.0)
       rails (>= 6.0, < 8.2)
 
@@ -103,12 +103,12 @@ GEM
     drb (2.2.3)
     erb (5.1.1)
     erubi (1.13.1)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashdiff (1.2.1)
@@ -119,7 +119,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.15.1)
+    json (2.18.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -136,8 +136,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.26.0)
     mutex_m (0.3.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -301,7 +301,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.4)
+    uri (1.1.1)
     useragent (0.16.11)
     webmock (3.25.1)
       addressable (>= 2.8.0)

--- a/lib/rails_cloudflare_turnstile/version.rb
+++ b/lib/rails_cloudflare_turnstile/version.rb
@@ -1,3 +1,3 @@
 module RailsCloudflareTurnstile
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end


### PR DESCRIPTION
## Summary

Updates Faraday dependency from 2.14.0 to 2.14.1 to address a medium-severity SSRF security vulnerability.

## Details

- **CVE**: CVE-2026-25765
- **GHSA**: GHSA-33mh-2634-fwr2
- **Severity**: Medium (CVSS 5.8)
- **Resolves**: https://github.com/instrumentl/rails-cloudflare-turnstile/security/dependabot/65

### Vulnerability Description

Faraday versions <= 2.14.0 are vulnerable to Server-Side Request Forgery (SSRF) via protocol-relative URLs. The `build_exclusive_url` method treats protocol-relative URLs (e.g., `//evil.com/path`) as network-path references that override the base URL's host, potentially allowing attackers to redirect requests to arbitrary hosts.

### Impact on This Gem

**This gem is NOT directly vulnerable** to the SSRF attack because:
- The Faraday URL is derived from `config.validation_url` (a configuration setting)
- User input is not passed to Faraday's request methods as URLs
- The only user-controlled data sent to Faraday is in the request body

However, updating to the patched version eliminates the dependency vulnerability and follows security best practices.

## Changes

- ✅ Updated Faraday: 2.14.0 → 2.14.1
- ✅ Bumped gem version: 0.4.4 → 0.4.5 (patch release)
- ✅ Updated CHANGELOG.md with security fix details
- ✅ All tests passing (30 examples, 0 failures)

## Additional Dependency Updates

The bundle update also updated some transitive dependencies:
- `faraday-net_http`: 3.4.1 → 3.4.2
- `json`: 2.15.1 → 2.18.1
- `net-http`: 0.6.0 → 0.9.1
- `uri`: 1.0.4 → 1.1.1

## Testing

```bash
bundle exec rspec
# 30 examples, 0 failures
```

## References

- [Faraday Security Advisory](https://github.com/lostisland/faraday/security/advisories/GHSA-33mh-2634-fwr2)
- [Faraday Release v2.14.1](https://github.com/lostisland/faraday/releases/tag/v2.14.1)
- [CVE-2026-25765](https://nvd.nist.gov/vuln/detail/CVE-2026-25765)