### PR TITLE
fix(deps): bump rack to 3.2.5 to fix CVE-2026-22860

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       stringio
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (3.2.3)
+    rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
## Summary

Closes DTI-90

Updates rack from 3.2.3 to 3.2.5 to fix high severity directory traversal vulnerability (CVE-2026-22860, CVSS 7.5).

## Changes

- Bumps rack to 3.2.5 in Gemfile.lock

## Verification

- ✅ All tests passing
- ✅ Bundle audit clean
- ✅ No style violations

Closes https://github.com/instrumentl/rails-cloudflare-turnstile/security/dependabot/66