### PR TITLE
chore(deps): upgrade action_text-trix from 2.1.17 to 2.1.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.17)
+    action_text-trix (2.1.18)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)


### PR DESCRIPTION
Upgrades `action_text-trix` to 2.1.18 to eliminate https://github.com/basecamp/trix/security/advisories/GHSA-53p3-c7vp-4mcc

<img width="943" height="460" alt="image" src="https://github.com/user-attachments/assets/b4cd9e13-cfd5-4b6f-91da-79706ac7c05c" />
